### PR TITLE
Introduce method chaining

### DIFF
--- a/eris.go
+++ b/eris.go
@@ -65,8 +65,8 @@ func Wrap(err error, msg string) statusError {
 // Wrapf adds additional context to all error types while maintaining the type of the original error.
 //
 // This is a convenience method for wrapping errors with formatted messages and is otherwise the same as Wrap.
-func Wrapf(err error, code Code, format string, args ...any) statusError {
-	return wrap(err, fmt.Sprintf(format, args...), code)
+func Wrapf(err error, format string, args ...any) statusError {
+	return wrap(err, fmt.Sprintf(format, args...), DEFAULT_ERROR_CODE_WRAP)
 }
 
 func wrap(err error, msg string, code Code) statusError {

--- a/eris.go
+++ b/eris.go
@@ -71,9 +71,9 @@ func Wrapf(err error, code Code, format string, args ...any) chainingError {
 
 func wrap(err error, msg string, code Code) chainingError {
 	if err == nil {
-		return &rootError{
-			isNil: true,
-		}
+		// Compiler needs to know concrete type in order to call functions of interface
+		var nilPtr *rootError
+		return nilPtr
 	}
 
 	// callers(4) skips runtime.Callers, stack.callers, this method, and Wrap(f)
@@ -270,13 +270,12 @@ type rootError struct {
 	stack  *stack // root error stack trace
 	code   Code
 	KVs    map[string]any // TODO: KVs should be lower-case. no need to export this
-	isNil  bool           // flag indicating whether the error is nil
 }
 
 // WithCode sets the error code.
 func (e *rootError) WithCode(code Code) chainingError {
-	if e.isNil {
-		return e
+	if e == nil {
+		return nil
 	}
 	e.code = code
 	return e
@@ -284,8 +283,8 @@ func (e *rootError) WithCode(code Code) chainingError {
 
 // WithProperty adds a key-value pair to the error.
 func (e *rootError) WithProperty(key string, value any) chainingError {
-	if e.isNil {
-		return e
+	if e == nil {
+		return nil
 	}
 	if e.KVs == nil {
 		e.KVs = make(map[string]any)
@@ -356,13 +355,12 @@ type wrapError struct {
 	frame *frame // wrap error stack frame
 	code  Code   // TODO: do we use this code or do we only ever use it in errLink?
 	KVs   map[string]any
-	isNil bool // flag indicating whether the error is nil
 }
 
 // WithCode sets the error code.
 func (e *wrapError) WithCode(code Code) chainingError {
-	if e.isNil {
-		return e
+	if e == nil {
+		return nil
 	}
 	e.code = code
 	return e
@@ -370,8 +368,8 @@ func (e *wrapError) WithCode(code Code) chainingError {
 
 // WithProperty adds a key-value pair to the error.
 func (e *wrapError) WithProperty(key string, value any) chainingError {
-	if e.isNil {
-		return e
+	if e == nil {
+		return nil
 	}
 	if e.KVs == nil {
 		e.KVs = make(map[string]any)

--- a/eris_test.go
+++ b/eris_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	globalErr          = eris.New("global error", eris.CodeUnknown)
+	globalErr          = eris.New("global error").WithCode(eris.CodeUnknown)
 	formattedGlobalErr = eris.Errorf("%v global error", eris.CodeUnknown, "formatted")
 )
 
@@ -53,9 +53,9 @@ func setupTestCase(wrapf bool, cause error, input []string) error {
 	err := cause
 	for _, str := range input {
 		if wrapf {
-			err = eris.Wrapf(err, eris.CodeUnknown, "%v", str)
+			err = eris.Wrapf(err, eris.CodeUnknown, "%v", str) // TODO: Change wrapf to chaining func
 		} else {
-			err = eris.Wrap(err, str, eris.CodeUnknown)
+			err = eris.Wrap(err, str).WithCode(eris.CodeUnknown)
 		}
 	}
 	return err
@@ -63,12 +63,12 @@ func setupTestCase(wrapf bool, cause error, input []string) error {
 
 func TestDefaultCodes(t *testing.T) {
 	// TODO: Change this to defaults function calls
-	newErr := eris.New("some error", eris.CodeUnknown)
+	newErr := eris.New("some error").WithCode(eris.CodeUnknown)
 	errCode := eris.GetCode(newErr)
 	if errCode != eris.CodeUnknown {
 		t.Errorf("New errors supposed to default to code 'unknown', but defaulted to %s", errCode)
 	}
-	wrapErr := eris.Wrap(newErr, "wrap err", eris.CodeInternal)
+	wrapErr := eris.Wrap(newErr, "wrap err").WithCode(eris.CodeInternal)
 	errCode = eris.GetCode(wrapErr)
 	if errCode != eris.CodeInternal {
 		t.Errorf("Wrap errors supposed to default to code 'internal', but defaulted to %s", errCode)
@@ -96,7 +96,7 @@ func TestErrorWrapping(t *testing.T) {
 			output: "code(unknown) even more context: code(unknown) additional context: code(unknown) formatted global error",
 		},
 		"standard error wrapping with a local root cause": {
-			cause:  eris.New("root error", eris.CodeUnknown),
+			cause:  eris.New("root error").WithCode(eris.CodeUnknown),
 			input:  []string{"additional context", "even more context"},
 			output: "code(unknown) even more context: code(unknown) additional context: code(unknown) root error",
 		},
@@ -235,7 +235,7 @@ func TestErrorUnwrap(t *testing.T) {
 		output []string // expected output
 	}{
 		"unwrapping error with internal root cause (eris.New)": {
-			cause: eris.New("root error", eris.CodeUnknown),
+			cause: eris.New("root error").WithCode(eris.CodeUnknown),
 			input: []string{"additional context", "even more context"},
 			output: []string{
 				"code(unknown) even more context: code(unknown) additional context: code(unknown) root error",
@@ -298,26 +298,26 @@ func TestErrorIs(t *testing.T) {
 		output  bool     // expected comparison result
 	}{
 		"root error (internal)": {
-			cause:   eris.New("root error", eris.CodeUnknown),
+			cause:   eris.New("root error").WithCode(eris.CodeUnknown),
 			input:   []string{"additional context", "even more context"},
-			compare: eris.New("root error", eris.CodeUnknown),
+			compare: eris.New("root error").WithCode(eris.CodeUnknown),
 			output:  true,
 		},
 		"error not in chain": {
-			cause:   eris.New("root error", eris.CodeUnknown),
-			compare: eris.New("other error", eris.CodeUnknown),
+			cause:   eris.New("root error").WithCode(eris.CodeUnknown),
+			compare: eris.New("other error").WithCode(eris.CodeUnknown),
 			output:  false,
 		},
 		"middle of chain (internal)": {
-			cause:   eris.New("root error", eris.CodeUnknown),
+			cause:   eris.New("root error").WithCode(eris.CodeUnknown),
 			input:   []string{"additional context", "even more context"},
-			compare: eris.New("additional context", eris.CodeUnknown),
+			compare: eris.New("additional context").WithCode(eris.CodeUnknown),
 			output:  true,
 		},
 		"another in middle of chain (internal)": {
-			cause:   eris.New("root error", eris.CodeUnknown),
+			cause:   eris.New("root error").WithCode(eris.CodeUnknown),
 			input:   []string{"additional context", "even more context"},
-			compare: eris.New("even more context", eris.CodeUnknown),
+			compare: eris.New("even more context").WithCode(eris.CodeUnknown),
 			output:  true,
 		},
 		"root error (external)": {
@@ -329,7 +329,7 @@ func TestErrorIs(t *testing.T) {
 		"wrapped error from global root error": {
 			cause:   globalErr,
 			input:   []string{"additional context", "even more context"},
-			compare: eris.Wrap(globalErr, "additional context", eris.CodeUnknown),
+			compare: eris.Wrap(globalErr, "additional context").WithCode(eris.CodeUnknown),
 			output:  true,
 		},
 		"comparing against external error": {
@@ -353,7 +353,7 @@ func TestErrorIs(t *testing.T) {
 			output: true,
 		},
 		"comparing against nil error": {
-			cause:   eris.New("root error", eris.CodeUnknown),
+			cause:   eris.New("root error").WithCode(eris.CodeUnknown),
 			compare: nil,
 			output:  false,
 		},
@@ -383,8 +383,8 @@ func TestErrorIs(t *testing.T) {
 
 func TestErrorAs(t *testing.T) {
 	externalError := errors.New("external error")
-	rootErr := eris.New("root error", eris.CodeUnknown)
-	wrappedErr := eris.Wrap(rootErr, "additional context", eris.CodeUnknown)
+	rootErr := eris.New("root error").WithCode(eris.CodeUnknown)
+	wrappedErr := eris.Wrap(rootErr, "additional context").WithCode(eris.CodeUnknown)
 	customErr := withLayer{
 		msg: "additional context",
 		err: withEmptyLayer{
@@ -437,7 +437,7 @@ func TestErrorAs(t *testing.T) {
 			output: nil,
 		},
 		"root error against external target": {
-			cause:  eris.New("root error", eris.CodeUnknown),
+			cause:  eris.New("root error").WithCode(eris.CodeUnknown),
 			target: &externalError,
 			match:  false,
 			output: nil,
@@ -449,7 +449,7 @@ func TestErrorAs(t *testing.T) {
 			output: nil,
 		},
 		"nil wrapped error against root error target": {
-			cause:  eris.Wrap(nil, "additional context", eris.CodeUnknown),
+			cause:  eris.Wrap(nil, "additional context").WithCode(eris.CodeUnknown),
 			target: &rootErr,
 			match:  false,
 			output: nil,
@@ -467,7 +467,7 @@ func TestErrorAs(t *testing.T) {
 			output: rootErr,
 		},
 		"root error against different root error": {
-			cause:  eris.New("other root error", eris.CodeUnknown),
+			cause:  eris.New("other root error").WithCode(eris.CodeUnknown),
 			target: &rootErr,
 			match:  false,
 			output: nil,
@@ -479,7 +479,7 @@ func TestErrorAs(t *testing.T) {
 			output: wrappedErr,
 		},
 		"wrapped error against different wrapped error": {
-			cause:  eris.Wrap(nil, "some other error", eris.CodeUnknown),
+			cause:  eris.Wrap(nil, "some other error").WithCode(eris.CodeUnknown),
 			target: &wrappedErr,
 			match:  false,
 			output: nil,
@@ -510,7 +510,7 @@ func TestErrorAs(t *testing.T) {
 }
 
 func TestErrorCause(t *testing.T) {
-	globalErr := eris.New("global error", eris.CodeUnknown)
+	globalErr := eris.New("global error").WithCode(eris.CodeUnknown)
 	extErr := errors.New("external error")
 	customErr := withMessage{
 		msg: "external error",
@@ -636,8 +636,8 @@ func (CustomErr) Error() string {
 
 func TestCustomErrorAs(t *testing.T) {
 	original := CustomErr{}
-	wrap1 := eris.Wrap(original, "wrap1", eris.CodeUnknown)
-	wrap2 := eris.Wrap(wrap1, "wrap2", eris.CodeUnknown)
+	wrap1 := eris.Wrap(original, "wrap1").WithCode(eris.CodeUnknown)
+	wrap2 := eris.Wrap(wrap1, "wrap2").WithCode(eris.CodeUnknown)
 
 	var customErr CustomErr
 	if !eris.As(wrap1, &customErr) {
@@ -655,7 +655,7 @@ func TestErrorFormatting(t *testing.T) {
 		output string   // expected output
 	}{
 		"standard error wrapping with internal root cause (eris.New)": {
-			cause:  eris.New("root error", eris.CodeUnknown),
+			cause:  eris.New("root error").WithCode(eris.CodeUnknown),
 			input:  []string{"additional context", "even more context"},
 			output: "code(unknown) even more context: code(unknown) additional context: code(unknown) root error",
 		},
@@ -719,11 +719,11 @@ func TestStackFrames(t *testing.T) {
 		isWrapErr bool     // flag for wrap error
 	}{
 		"root error": {
-			cause:     eris.New("root error", eris.CodeUnknown),
+			cause:     eris.New("root error").WithCode(eris.CodeUnknown),
 			isWrapErr: false,
 		},
 		"wrapped error": {
-			cause:     eris.New("root error", eris.CodeUnknown),
+			cause:     eris.New("root error").WithCode(eris.CodeUnknown),
 			input:     []string{"additional context", "even more context"},
 			isWrapErr: true,
 		},

--- a/eris_test.go
+++ b/eris_test.go
@@ -53,7 +53,7 @@ func setupTestCase(wrapf bool, cause error, input []string) error {
 	err := cause
 	for _, str := range input {
 		if wrapf {
-			err = eris.Wrapf(err, eris.CodeUnknown, "%v", str) // TODO: Change wrapf to chaining func
+			err = eris.Wrapf(err, "%v", str).WithCode(eris.CodeUnknown)
 		} else {
 			err = eris.Wrap(err, str).WithCode(eris.CodeUnknown)
 		}

--- a/examples_test.go
+++ b/examples_test.go
@@ -46,7 +46,7 @@ func TestExampleToJSON_external(t *testing.T) {
 func ExampleToJSON_global() {
 	// example func that wraps a global error value
 	readFile := func(fname string) error {
-		return eris.Wrapf(ErrUnexpectedEOF, eris.CodeUnknown, "error reading file '%v'", fname) // line 6
+		return eris.Wrapf(ErrUnexpectedEOF, "error reading file '%v'", fname).WithCode(eris.CodeUnknown)
 	}
 
 	// example func that catches and returns an error without modification
@@ -103,7 +103,7 @@ func ExampleToJSON_local() {
 		// read the file
 		err := readFile(fname) // line 9
 		if err != nil {
-			return eris.Wrapf(err, eris.CodeUnknown, "error reading file '%v'", fname) // line 11
+			return eris.Wrapf(err, "error reading file '%v'", fname).WithCode(eris.CodeUnknown)
 		}
 		return nil
 	}
@@ -123,7 +123,7 @@ func ExampleToJSON_local() {
 		// process the file
 		err := processFile(fname) // line 29
 		if err != nil {
-			return eris.Wrapf(err, eris.CodeUnknown, "error printing file '%v'", fname) // line 31
+			return eris.Wrapf(err, "error printing file '%v'", fname).WithCode(eris.CodeUnknown)
 		}
 		return nil
 	}
@@ -194,7 +194,7 @@ func TestExampleToString_external(t *testing.T) {
 func ExampleToString_global() {
 	// example func that wraps a global error value
 	readFile := func(fname string) error {
-		return eris.Wrapf(FormattedErrUnexpectedEOF, eris.CodeUnknown, "error reading file '%v'", fname) // line 6
+		return eris.Wrapf(FormattedErrUnexpectedEOF, "error reading file '%v'", fname).WithCode(eris.CodeUnknown)
 	}
 
 	// example func that catches and returns an error without modification
@@ -212,7 +212,7 @@ func ExampleToString_global() {
 		// parse the file
 		err := parseFile(fname) // line 22
 		if err != nil {
-			return eris.Wrapf(err, eris.CodeUnknown, "error processing file '%v'", fname) // line 24
+			return eris.Wrapf(err, "error processing file '%v'", fname).WithCode(eris.CodeUnknown)
 		}
 		return nil
 	}
@@ -260,7 +260,7 @@ func ExampleToString_local() {
 		// read the file
 		err := readFile(fname) // line 9
 		if err != nil {
-			return eris.Wrapf(err, eris.CodeUnknown, "error reading file '%v'", fname) // line 11
+			return eris.Wrapf(err, "error reading file '%v'", fname).WithCode(eris.CodeUnknown)
 		}
 		return nil
 	}

--- a/examples_test.go
+++ b/examples_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	ErrUnexpectedEOF          = eris.New("unexpected EOF", eris.CodeUnknown)
+	ErrUnexpectedEOF          = eris.New("unexpected EOF").WithCode(eris.CodeUnknown)
 	FormattedErrUnexpectedEOF = eris.Errorf("unexpected %v", eris.CodeUnknown, "EOF")
 )
 
@@ -95,7 +95,7 @@ func TestExampleToJSON_global(t *testing.T) {
 func ExampleToJSON_local() {
 	// example func that returns an eris error
 	readFile := func(fname string) error {
-		return eris.New("unexpected EOF", eris.CodeUnknown) // line 3
+		return eris.New("unexpected EOF").WithCode(eris.CodeUnknown) // line 3
 	}
 
 	// example func that catches an error and wraps it with additional context
@@ -252,7 +252,7 @@ func TestExampleToString_global(t *testing.T) {
 func ExampleToString_local() {
 	// example func that returns an eris error
 	readFile := func(fname string) error {
-		return eris.New("unexpected EOF", eris.CodeUnknown) // line 3
+		return eris.New("unexpected EOF").WithCode(eris.CodeUnknown) // line 3
 	}
 
 	// example func that catches an error and wraps it with additional context
@@ -295,15 +295,15 @@ func TestExampleToString_local(t *testing.T) {
 }
 
 func f() error {
-	return eris.New("error message", eris.CodeDeadlineExceeded)
+	return eris.New("error message").WithCode(eris.CodeDeadlineExceeded)
 }
 
 func g() error {
-	return eris.Wrap(f(), "in function g", eris.CodeCanceled)
+	return eris.Wrap(f(), "in function g").WithCode(eris.CodeCanceled)
 }
 
 func h() error {
-	return eris.Wrap(g(), "in function h", eris.CodeAborted)
+	return eris.Wrap(g(), "in function h").WithCode(eris.CodeAborted)
 }
 
 func TestMainFunc(t *testing.T) {

--- a/format_test.go
+++ b/format_test.go
@@ -225,23 +225,23 @@ func TestFormatJSONwithKVs(t *testing.T) {
 	}{
 		"basic root error + simple kvs": {
 			input:  eris.New("root error").WithCode(eris.CodeCanceled).WithProperty("key", "value"),
-			output: `{"root":{"KVs":{"key","value"},"code":"canceled","message":"root error"}}`,
+			output: `{"root":{"KVs":{"key":"value"},"code":"canceled","message":"root error"}}`,
 		},
-		"basic wrapped error + kvs with obj w/o serializer": {
+		"basic wrapped error + kvs with objects": {
 			input:  eris.Wrap(eris.Wrap(eris.New("root error").WithCode(eris.CodeNotFound).WithProperty("obj", nonSerializableObj), "additional context").WithCode(eris.CodeAlreadyExists).WithProperty("obj", serializableObj), "outer error"),
-			output: `{"root":{"KVs":{"obj":{}},"code":"not found","message":"root error"},"wrap":[{"KVs":{"intPtr":1,"nullPtr":null,"objPtr":{"obj":{"a":"aVal","b":1}}},"code":"unknown","message":"even more context"},{"code":"already exists","message":"additional context"}]}`,
+			output: `{"root":{"KVs":{"obj":{}},"code":"not found","message":"root error"},"wrap":[{"code":"internal","message":"outer error"},{"KVs":{"obj":{"a":"aVal","b":1}},"code":"already exists","message":"additional context"}]}`,
 		},
-		"basic wrapped error + kvs with obj w serializer": {
+		"basic wrapped error + kvs with objects 2": {
 			input:  eris.Wrap(eris.Wrap(eris.New("root error").WithCode(eris.CodeNotFound).WithProperty("obj", serializableObj), "additional context"), "outer error"),
-			output: `{"root":{"KVs":{"obj":{"a":"aVal","b":1}},"code":"not found","message":"root error"},"wrap":[{"code":"unknown","message":"even more context"},{"KVs":{"obj":{}},"code":"already exists","message":"additional context"}]}`,
+			output: `{"root":{"KVs":{"obj":{"a":"aVal","b":1}},"code":"not found","message":"root error"},"wrap":[{"code":"internal","message":"outer error"},{"code":"internal","message":"additional context"}]}`,
 		},
 		"basic wrapped error + ptr kvs": {
 			input:  eris.Wrap(eris.Wrap(eris.New("root error").WithProperty("ptr", nil), "additional context"), "even more context"),
-			output: `{"root":{"KVs":{"intPtr":1,"nullPtr":null,"objPtr":{"obj":{"a":"aVal","b":1}}},"code":"not found","message":"root error"},"wrap":[{"code":"unknown","message":"even more context"},{"code":"already exists","message":"additional context"}]}`,
+			output: `{"root":{"KVs":{"ptr":null},"code":"unknown","message":"root error"},"wrap":[{"code":"internal","message":"even more context"},{"code":"internal","message":"additional context"}]}`,
 		},
 		"external error + valid kvs": {
 			input:  eris.Wrap(errors.New("external error"), "additional context").WithCode(eris.CodeNotFound),
-			output: `{"external":"external error","root":{"KVs":{"key":"value","key2":2,"key3":true,"key4":["a","b","c"]},"code":"not found","message":"additional context"}}`,
+			output: `{"external":"external error","root":{"code":"not found","message":"additional context"}}`,
 		},
 	}
 

--- a/format_test.go
+++ b/format_test.go
@@ -26,7 +26,7 @@ func TestUnpack(t *testing.T) {
 			output: eris.UnpackedError{},
 		},
 		"standard error wrapping with internal root cause (eris.New)": {
-			cause: eris.New("root error", eris.CodeUnknown),
+			cause: eris.New("root error").WithCode(eris.CodeUnknown),
 			input: []string{"additional context", "even more context"},
 			output: eris.UnpackedError{
 				ErrRoot: eris.ErrRoot{
@@ -110,19 +110,19 @@ func TestFormatStr(t *testing.T) {
 		output string
 	}{
 		"basic root error": {
-			input:  eris.New("root error", eris.CodeUnknown),
+			input:  eris.New("root error").WithCode(eris.CodeUnknown),
 			output: "code(unknown) root error",
 		},
 		"basic wrapped error": {
 			input: eris.Wrap(
 				eris.Wrap(
-					eris.New("root error", eris.CodeAlreadyExists),
-					"additional context", eris.CodeInvalidArgument),
-				"even more context", eris.CodeInvalidArgument),
+					eris.New("root error").WithCode(eris.CodeAlreadyExists),
+					"additional context").WithCode(eris.CodeInvalidArgument),
+				"even more context").WithCode(eris.CodeInvalidArgument),
 			output: "code(invalid argument) even more context: code(invalid argument) additional context: code(already exists) root error",
 		},
 		"external wrapped error": {
-			input:  eris.Wrap(errors.New("external error"), "additional context", eris.CodeUnknown),
+			input:  eris.Wrap(errors.New("external error"), "additional context").WithCode(eris.CodeUnknown),
 			output: "code(unknown) additional context: external error",
 		},
 		"external error": {
@@ -131,15 +131,15 @@ func TestFormatStr(t *testing.T) {
 		},
 		// This is the expected behavior, since this error does not hold any information
 		"empty error": {
-			input:  eris.New("", eris.CodeUnknown),
+			input:  eris.New("").WithCode(eris.CodeUnknown),
 			output: "",
 		},
 		"empty wrapped external error": {
-			input:  eris.Wrap(errors.New(""), "additional context", eris.CodeUnknown),
+			input:  eris.Wrap(errors.New(""), "additional context").WithCode(eris.CodeUnknown),
 			output: "code(unknown) additional context: ",
 		},
 		"empty wrapped error": {
-			input:  eris.Wrap(eris.New("", eris.CodeUnknown), "additional context", eris.CodeUnknown),
+			input:  eris.Wrap(eris.New("").WithCode(eris.CodeUnknown), "additional context").WithCode(eris.CodeUnknown),
 			output: "code(unknown) additional context: ",
 		},
 		// TODO: add tests for KVs and err code
@@ -161,12 +161,12 @@ func TestInvertedFormatStr(t *testing.T) {
 		output string
 	}{
 		"basic wrapped error": {
-			input:  eris.Wrap(eris.Wrap(eris.New("root error", eris.CodeUnknown), "additional context", eris.CodeUnknown), "even more context", eris.CodeUnknown),
+			input:  eris.Wrap(eris.Wrap(eris.New("root error").WithCode(eris.CodeUnknown), "additional context").WithCode(eris.CodeUnknown), "even more context").WithCode(eris.CodeUnknown),
 			output: "code(unknown) root error: code(unknown) additional context: code(unknown) even more context",
 		},
 		// TODO: Is this the expected behavior? Should an external error have a default code unknown?
 		"external wrapped error": {
-			input:  eris.Wrap(errors.New("external error"), "additional context", eris.CodeUnknown),
+			input:  eris.Wrap(errors.New("external error"), "additional context").WithCode(eris.CodeUnknown),
 			output: "external error: code(unknown) additional context",
 		},
 		"external error": {
@@ -174,11 +174,11 @@ func TestInvertedFormatStr(t *testing.T) {
 			output: "external error code(canceled) ",
 		},
 		"empty wrapped external error": {
-			input:  eris.Wrap(errors.New("some err"), "additional context", eris.CodeUnknown),
+			input:  eris.Wrap(errors.New("some err"), "additional context").WithCode(eris.CodeUnknown),
 			output: "some err: code(unknown) additional context",
 		},
 		"empty wrapped error": {
-			input:  eris.Wrap(eris.New("err", eris.CodeUnknown), "additional context", eris.CodeUnknown),
+			input:  eris.Wrap(eris.New("err").WithCode(eris.CodeUnknown), "additional context").WithCode(eris.CodeUnknown),
 			output: "code(unknown) err: code(unknown) additional context",
 		},
 	}
@@ -197,21 +197,12 @@ func TestInvertedFormatStr(t *testing.T) {
 }
 
 func TestFormatJSONwithKVs(t *testing.T) {
-	simpleKVs := map[string]any{
-		"key":  "value",
-		"key2": 2,
-		"key3": true,
-		"key4": []string{"a", "b", "c"},
-	}
-
-	KVsObjNoJson := map[string]any{
-		"obj": struct {
-			a string
-			b int
-		}{
-			a: "a",
-			b: 1,
-		},
+	nonSerializableObj := struct {
+		a string
+		b int
+	}{
+		a: "a",
+		b: 1,
 	}
 
 	serializableObj := struct {
@@ -220,16 +211,6 @@ func TestFormatJSONwithKVs(t *testing.T) {
 	}{
 		A: "aVal",
 		B: 1,
-	}
-	KVsObjJson := map[string]any{
-		"obj": serializableObj,
-	}
-
-	intVal := 1
-	ptrKVs := map[string]any{
-		"nullPtr": nil,
-		"intPtr":  &intVal,
-		"objPtr":  &KVsObjJson,
 	}
 
 	// TODO: valid kvs with custom object that can be serialized
@@ -243,23 +224,23 @@ func TestFormatJSONwithKVs(t *testing.T) {
 		output string
 	}{
 		"basic root error + simple kvs": {
-			input:  eris.New_with_KVs("root error", eris.CodeCanceled, simpleKVs),
-			output: `{"root":{"KVs":{"key":"value","key2":2,"key3":true,"key4":["a","b","c"]},"code":"canceled","message":"root error"}}`,
+			input:  eris.New("root error").WithCode(eris.CodeCanceled).WithProperty("key", "value"),
+			output: `{"root":{"KVs":{"key","value"},"code":"canceled","message":"root error"}}`,
 		},
 		"basic wrapped error + kvs with obj w/o serializer": {
-			input:  eris.Wrap_with_KVs(eris.Wrap(eris.New_with_KVs("root error", eris.CodeNotFound, KVsObjNoJson), "additional context", eris.CodeAlreadyExists), "even more context", eris.CodeUnknown, ptrKVs),
+			input:  eris.Wrap(eris.Wrap(eris.New("root error").WithCode(eris.CodeNotFound).WithProperty("obj", nonSerializableObj), "additional context").WithCode(eris.CodeAlreadyExists).WithProperty("obj", serializableObj), "outer error"),
 			output: `{"root":{"KVs":{"obj":{}},"code":"not found","message":"root error"},"wrap":[{"KVs":{"intPtr":1,"nullPtr":null,"objPtr":{"obj":{"a":"aVal","b":1}}},"code":"unknown","message":"even more context"},{"code":"already exists","message":"additional context"}]}`,
 		},
 		"basic wrapped error + kvs with obj w serializer": {
-			input:  eris.Wrap(eris.Wrap_with_KVs(eris.New_with_KVs("root error", eris.CodeNotFound, KVsObjJson), "additional context", eris.CodeAlreadyExists, KVsObjNoJson), "even more context", eris.CodeUnknown),
+			input:  eris.Wrap(eris.Wrap(eris.New("root error").WithCode(eris.CodeNotFound).WithProperty("obj", serializableObj), "additional context"), "outer error"),
 			output: `{"root":{"KVs":{"obj":{"a":"aVal","b":1}},"code":"not found","message":"root error"},"wrap":[{"code":"unknown","message":"even more context"},{"KVs":{"obj":{}},"code":"already exists","message":"additional context"}]}`,
 		},
 		"basic wrapped error + ptr kvs": {
-			input:  eris.Wrap(eris.Wrap(eris.New_with_KVs("root error", eris.CodeNotFound, ptrKVs), "additional context", eris.CodeAlreadyExists), "even more context", eris.CodeUnknown),
+			input:  eris.Wrap(eris.Wrap(eris.New("root error").WithProperty("ptr", nil), "additional context"), "even more context"),
 			output: `{"root":{"KVs":{"intPtr":1,"nullPtr":null,"objPtr":{"obj":{"a":"aVal","b":1}}},"code":"not found","message":"root error"},"wrap":[{"code":"unknown","message":"even more context"},{"code":"already exists","message":"additional context"}]}`,
 		},
 		"external error + valid kvs": {
-			input:  eris.Wrap_with_KVs(errors.New("external error"), "additional context", eris.CodeNotFound, simpleKVs),
+			input:  eris.Wrap(errors.New("external error"), "additional context").WithCode(eris.CodeNotFound),
 			output: `{"external":"external error","root":{"KVs":{"key":"value","key2":2,"key3":true,"key4":["a","b","c"]},"code":"not found","message":"additional context"}}`,
 		},
 	}
@@ -281,15 +262,15 @@ func TestFormatJSON(t *testing.T) {
 		output string
 	}{
 		"basic root error": {
-			input:  eris.New("root error", eris.CodeCanceled),
+			input:  eris.New("root error").WithCode(eris.CodeCanceled),
 			output: `{"root":{"code":"canceled","message":"root error"}}`,
 		},
 		"basic wrapped error": {
-			input:  eris.Wrap(eris.Wrap(eris.New("root error", eris.CodeNotFound), "additional context", eris.CodeAlreadyExists), "even more context", eris.CodeUnknown),
+			input:  eris.Wrap(eris.Wrap(eris.New("root error").WithCode(eris.CodeNotFound), "additional context").WithCode(eris.CodeAlreadyExists), "even more context").WithCode(eris.CodeUnknown),
 			output: `{"root":{"code":"not found","message":"root error"},"wrap":[{"code":"unknown","message":"even more context"},{"code":"already exists","message":"additional context"}]}`,
 		},
 		"external error": {
-			input:  eris.Wrap(errors.New("external error"), "additional context", eris.CodeDataLoss),
+			input:  eris.Wrap(errors.New("external error"), "additional context").WithCode(eris.CodeDataLoss),
 			output: `{"external":"external error","root":{"code":"data loss","message":"additional context"}}`,
 		},
 	}
@@ -309,7 +290,7 @@ func TestInvertedFormatJSON(t *testing.T) {
 		output string
 	}{
 		"basic wrapped error": {
-			input:  eris.Wrap(eris.Wrap(eris.New("root error", eris.CodeAlreadyExists), "additional context", eris.CodeUnknown), "even more context", eris.CodeUnknown),
+			input:  eris.Wrap(eris.Wrap(eris.New("root error").WithCode(eris.CodeAlreadyExists), "additional context").WithCode(eris.CodeUnknown), "even more context").WithCode(eris.CodeUnknown),
 			output: `{"root":{"code":"already exists","message":"root error"},"wrap":[{"code":"unknown","message":"additional context"},{"code":"unknown","message":"even more context"}]}`,
 		},
 	}
@@ -333,7 +314,7 @@ func TestFormatJSONWithStack(t *testing.T) {
 		wrapOutput []map[string]any
 	}{
 		"basic wrapped error": {
-			input: eris.Wrap(eris.Wrap(eris.New("root error", eris.CodePermissionDenied), "additional context", eris.CodeUnavailable), "even more context", eris.CodeUnknown),
+			input: eris.Wrap(eris.Wrap(eris.New("root error").WithCode(eris.CodePermissionDenied), "additional context").WithCode(eris.CodeUnavailable), "even more context").WithCode(eris.CodeUnknown),
 			rootOutput: map[string]any{
 				"code":    "permission denied",
 				"message": "root error",

--- a/stack_test.go
+++ b/stack_test.go
@@ -38,7 +38,7 @@ func ReadFile(fname string, global bool, external bool) error {
 	} else { // global external
 		err = fmt.Errorf("external context: %w", errExt)
 	}
-	return eris.Wrapf(err, eris.CodeUnknown, "error reading file '%v'", fname)
+	return eris.Wrapf(err, "error reading file '%v'", fname).WithCode(eris.CodeUnknown)
 }
 
 // example func that just catches and returns an error.
@@ -55,7 +55,7 @@ func ProcessFile(fname string, global bool, external bool) error {
 	// parse the file
 	err := ParseFile(fname, global, external)
 	if err != nil {
-		return eris.Wrapf(err, eris.CodeUnknown, "error processing file '%v'", fname)
+		return eris.Wrapf(err, "error processing file '%v'", fname).WithCode(eris.CodeUnknown)
 	}
 	return nil
 }

--- a/stack_test.go
+++ b/stack_test.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	errEOF = eris.New("unexpected EOF", eris.CodeUnknown)
+	errEOF = eris.New("unexpected EOF").WithCode(eris.CodeUnknown)
 	errExt = errors.New("external error")
 )
 
@@ -30,7 +30,7 @@ var (
 func ReadFile(fname string, global bool, external bool) error {
 	var err error
 	if !external && !global { // local eris
-		err = eris.New("unexpected EOF", eris.CodeUnknown)
+		err = eris.New("unexpected EOF").WithCode(eris.CodeUnknown)
 	} else if !external && global { // global eris
 		err = errEOF
 	} else if external && !global { // local external
@@ -189,7 +189,7 @@ func TestGoRoutines(t *testing.T) {
 
 	go func() {
 		err := dummyStack()
-		err = eris.Wrap(err, "error reading file", eris.CodeUnknown)
+		err = eris.Wrap(err, "error reading file").WithCode(eris.CodeUnknown)
 
 		// verify the stack frames match expected values
 		uerr := eris.Unpack(err)
@@ -201,5 +201,5 @@ func TestGoRoutines(t *testing.T) {
 }
 
 func dummyStack() error {
-	return eris.New("unexpected EOF", eris.CodeUnknown)
+	return eris.New("unexpected EOF").WithCode(eris.CodeUnknown)
 }


### PR DESCRIPTION
## What's changed and what's your intention?

We are now able to create errors like these: 

```go 
eris.Wrap(
	eris.Wrap(
		eris.New("root error").WithProperty("obj", serializableObj), 	// New: code defaults to unknown
	"additional context"),  					        // Wrap: code defaults to internal
"outer error")
```

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
