### PR TITLE
fix: wrap nil shoule be nil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 
 # Output of the go coverage tool
 cover.out
+cover.html
 
 # Dependency directories
 vendor/

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ docs:
 ## Run the tests
 test:
 	@echo Running tests
-	@go test -race -v .
+	@go test -race -covermode=atomic -coverprofile=cover.out -v .
+	@go tool cover -html cover.out -o cover.html
 
 tests: test
 

--- a/codes.go
+++ b/codes.go
@@ -80,7 +80,7 @@ const (
 	DEFAULT_UNKNOWN_CODE = CodeUnknown
 )
 
-// fromGrpc converts a grpc code to an eris code. Returns false if mapping failed
+// fromGrpc converts a grpc code to an eris code. Returns false if mapping failed.
 func fromGrpc(c grpc.Code) (Code, bool) {
 	if c == grpc.OK {
 		return DEFAULT_UNKNOWN_CODE, false
@@ -138,7 +138,7 @@ func (c Code) ToGrpc() grpc.Code {
 
 type HTTPStatus int
 
-// fromHttp converts a http code to an eris code. Returns false if mapping failed
+// fromHttp converts a http code to an eris code. Returns false if mapping failed.
 func fromHttp(code HTTPStatus) (Code, bool) {
 	// mapping according to https://github.com/lobocv/simplerr/blob/master/ecosystem/http/translate_error_code.go
 	if code == 200 {

--- a/eris.go
+++ b/eris.go
@@ -76,9 +76,7 @@ func Wrapf(err error, format string, args ...any) statusError {
 
 func wrap(err error, msg string, code Code) statusError {
 	if err == nil {
-		// Compiler needs to know concrete type in order to call functions of interface
-		var nilPtr *rootError
-		return nilPtr
+		return nil
 	}
 
 	// callers(4) skips runtime.Callers, stack.callers, this method, and Wrap(f)

--- a/eris_test.go
+++ b/eris_test.go
@@ -9,8 +9,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/risingwavelabs/eris"
 	grpc "google.golang.org/grpc/codes"
+
+	"github.com/risingwavelabs/eris"
 )
 
 var (
@@ -776,5 +777,14 @@ func TestOkCode(t *testing.T) {
 	err = eris.New("everything went fine again").WithCodeHttp(http.StatusOK)
 	if err != nil {
 		t.Errorf("expected nil error if grpc status is OK, but error was %v", err)
+	}
+}
+
+func TestWrapType(t *testing.T) {
+	var err error = nil
+	var erisErr = eris.Wrapf(err, "test error")
+
+	if erisErr != nil {
+		t.Errorf("expected nil error if wrap nil error, but error was %v", erisErr)
 	}
 }

--- a/eris_test.go
+++ b/eris_test.go
@@ -201,6 +201,18 @@ func TestExternalErrorWrapping(t *testing.T) {
 		//			"external error",
 		//		},
 		//	},
+		"implicate wrap when add field to external error": {
+			cause: eris.With(
+				errors.New("external error"),
+				eris.Codes(eris.CodeCanceled), eris.KVs("key", "value"),
+			),
+			input: []string{"even more context"},
+			output: []string{
+				"code(unknown) even more context: code(canceled) KVs(map[key:value]) with property: external error",
+				"code(canceled) KVs(map[key:value]) with property: external error",
+				"external error",
+			},
+		},
 	}
 
 	for desc, tc := range tests {

--- a/examples_test.go
+++ b/examples_test.go
@@ -46,7 +46,7 @@ func TestExampleToJSON_external(t *testing.T) {
 func ExampleToJSON_global() {
 	// example func that wraps a global error value
 	readFile := func(fname string) error {
-		return eris.Wrapf(ErrUnexpectedEOF, "error reading file '%v'", fname).WithCode(eris.CodeUnknown)
+		return eris.WithCode(eris.Wrapf(ErrUnexpectedEOF, "error reading file '%v'", fname), eris.CodeUnknown)
 	}
 
 	// example func that catches and returns an error without modification
@@ -104,7 +104,7 @@ func ExampleToJSON_local() {
 		// read the file
 		err := readFile(fname) // line 9
 		if err != nil {
-			return eris.Wrapf(err, "error reading file '%v'", fname).WithCode(eris.CodeUnknown)
+			return eris.WithCode(eris.Wrapf(err, "error reading file '%v'", fname), eris.CodeUnknown)
 		}
 		return nil
 	}
@@ -124,7 +124,7 @@ func ExampleToJSON_local() {
 		// process the file
 		err := processFile(fname) // line 29
 		if err != nil {
-			return eris.Wrapf(err, "error printing file '%v'", fname).WithCode(eris.CodeUnknown)
+			return eris.WithCode(eris.Wrapf(err, "error printing file '%v'", fname), eris.CodeUnknown)
 		}
 		return nil
 	}
@@ -198,7 +198,7 @@ func TestExampleToString_external(t *testing.T) {
 func ExampleToString_global() {
 	// example func that wraps a global error value
 	readFile := func(fname string) error {
-		return eris.Wrapf(FormattedErrUnexpectedEOF, "error reading file '%v'", fname).WithProperty("file", fname)
+		return eris.WithProperty(eris.Wrapf(FormattedErrUnexpectedEOF, "error reading file '%v'", fname), "file", fname)
 	}
 
 	// example func that catches and returns an error without modification
@@ -216,7 +216,7 @@ func ExampleToString_global() {
 		// parse the file
 		err := parseFile(fname) // line 22
 		if err != nil {
-			return eris.Wrapf(err, "error processing file '%v'", fname).WithCode(eris.CodeDeadlineExceeded)
+			return eris.WithCode(eris.Wrapf(err, "error processing file '%v'", fname), eris.CodeDeadlineExceeded)
 		}
 		return nil
 	}
@@ -266,7 +266,7 @@ func ExampleToString_local() {
 		// read the file
 		err := readFile(fname) // line 9
 		if err != nil {
-			return eris.Wrapf(err, "error reading file '%v'", fname).WithProperty("foo", "bar")
+			return eris.WithProperty(eris.Wrapf(err, "error reading file '%v'", fname), "foo", "bar")
 		}
 		return nil
 	}
@@ -305,11 +305,11 @@ func f() error {
 }
 
 func g() error {
-	return eris.Wrap(f(), "in function g").WithCode(eris.CodeCanceled)
+	return eris.WithCode(eris.Wrap(f(), "in function g"), eris.CodeCanceled)
 }
 
 func h() error {
-	return eris.Wrap(g(), "in function h").WithCode(eris.CodeAborted)
+	return eris.WithCode(eris.Wrap(g(), "in function h"), eris.CodeAborted)
 }
 
 func TestMainFunc(t *testing.T) {

--- a/stack_test.go
+++ b/stack_test.go
@@ -38,7 +38,7 @@ func ReadFile(fname string, global bool, external bool) error {
 	} else { // global external
 		err = fmt.Errorf("external context: %w", errExt)
 	}
-	return eris.Wrapf(err, "error reading file '%v'", fname).WithCode(eris.CodeUnknown)
+	return eris.WithCode(eris.Wrapf(err, "error reading file '%v'", fname), eris.CodeUnknown)
 }
 
 // example func that just catches and returns an error.
@@ -55,7 +55,7 @@ func ProcessFile(fname string, global bool, external bool) error {
 	// parse the file
 	err := ParseFile(fname, global, external)
 	if err != nil {
-		return eris.Wrapf(err, "error processing file '%v'", fname).WithCode(eris.CodeUnknown)
+		return eris.WithCode(eris.Wrapf(err, "error processing file '%v'", fname), eris.CodeUnknown)
 	}
 	return nil
 }
@@ -189,7 +189,7 @@ func TestGoRoutines(t *testing.T) {
 
 	go func() {
 		err := dummyStack()
-		err = eris.Wrap(err, "error reading file").WithCode(eris.CodeUnknown)
+		err = eris.WithCode(eris.Wrap(err, "error reading file"), eris.CodeUnknown)
 
 		// verify the stack frames match expected values
 		uerr := eris.Unpack(err)


### PR DESCRIPTION
## What's changed and what's your intention?

This is a bug produced on the dev stack.

Currently, `eris.Wrap(nil, "message") != nil` returns true. It causes [this line](https://github.com/risingwavelabs/eris/blob/bea618eb38a91a8d9f20cfea87b9477fd115b03a/format.go#L281) panic when we want to log this error
`panic: runtime error: invalid memory address or nil pointer dereference`

> If you don't know why `eris.Wrap(nil, "message") != nil` returns true, you can refer to:
The Go Programming Language, Chapter 7.5
English version: [The Go Programming Language pdf](https://github.com/neo-liang-sap/book/blob/master/Go/The.Go.Programming.Language.pdf) page 200
Chinese version: [Go语言圣经](https://github.com/neo-liang-sap/book/blob/master/Go/The.Go.Programming.Language.pdf)

This pr is a solution. But it will make `eris.Wrap(nil, "message").WithCode(code)` panic.
I think we may need to change the syntax of `eris.Wrap(nil, "message").WithCode(code)`

---

There is the stack trace of the dev stack panic, I think it's due to the above bug:
```json
{
  "workflow_id": "0d562438-0b7d-4f36-8319-7c18149b7ce4",
  "type": "Monitor",
  "state": "RunningWorkflow",
  "panic": {
    "external": "runtime error: invalid memory address or nil pointer dereference",
    "root": {
      "code": "internal",
      "message": "panic error",
      "stack": [
        "engine.(*Engine).process:/app/mgmt/cmd/workflow-engine/engine/engine.go:334",
        "workflow.(*Workflow).Transition:/app/mgmt/internal/workflow/workflow.go:73",
        "zap.(*Logger).Warn:/go/pkg/mod/go.uber.org/zap@v1.24.0/logger.go:228",
        "zapcore.(*CheckedEntry).Write:/go/pkg/mod/go.uber.org/zap@v1.24.0/zapcore/entry.go:255",
        "zapcore.(*ioCore).Write:/go/pkg/mod/go.uber.org/zap@v1.24.0/zapcore/core.go:95",
        "zapx.consoleEncoder.EncodeEntry:/app/shared/logger/zapx/encoder.go:61",
        "zapx.consoleEncoder.writeContext:/app/shared/logger/zapx/encoder.go:84",
        "zapx.addFields:/app/shared/logger/zapx/json_encoder.go:395",
        "zapx.addTo:/app/shared/logger/zapx/field.go:124",
        "zapx.encodeError:/app/shared/logger/zapx/error.go:30",
        "eris.ToJSON:/go/pkg/mod/github.com/risingwavelabs/eris@v1.1.0/format.go:205",
        "eris.ToCustomJSON:/go/pkg/mod/github.com/risingwavelabs/eris@v1.1.0/format.go:249",
        "eris.Unpack:/go/pkg/mod/github.com/risingwavelabs/eris@v1.1.0/format.go:281",
        "runtime.sigpanic:/usr/local/go/src/runtime/signal_unix.go:835",
        "runtime.panicmem:/usr/local/go/src/runtime/panic.go:260",
        "runtime.gopanic:/usr/local/go/src/runtime/panic.go:884",
        "engine.(*Engine).handleTask.func1:/app/mgmt/cmd/workflow-engine/engine/engine.go:268"
      ]
    }
  }
}
```

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
