### PR TITLE
fix: start code from 0

### DIFF
--- a/codes.go
+++ b/codes.go
@@ -12,7 +12,7 @@ type Code int
 // These are common impact error codes that are found throughout our services.
 const (
 	// The operation was cancelled, typically by the caller.
-	CodeCanceled Code = iota
+	CodeCanceled Code = iota + 1
 	// Unknown error. For example, this error may be returned when a Status value received from another address space belongs to an error space that is not known in this address space. Also errors raised by APIs that do not return enough error information may be converted to this error.
 	CodeUnknown
 	// The client specified an invalid argument. Note that this differs from FAILED_PRECONDITION. INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the system (e.g., a malformed file name).

--- a/format_test.go
+++ b/format_test.go
@@ -127,7 +127,7 @@ func TestFormatStr(t *testing.T) {
 		},
 		"external error": {
 			input:  errors.New("external error"),
-			output: "code(canceled) external error",
+			output: "code(unknown) external error",
 		},
 		// This is the expected behavior, since this error does not hold any information
 		"empty error": {
@@ -175,7 +175,7 @@ func TestInvertedFormatStr(t *testing.T) {
 		},
 		"external error": {
 			input:  errors.New("external error"),
-			output: "external error code(canceled) ",
+			output: "external error code(unknown) ",
 		},
 		"empty wrapped external error": {
 			input:  eris.WithCode(eris.Wrap(errors.New("some err"), "additional context"), eris.CodeUnknown),


### PR DESCRIPTION
Otherwise, if not specified, CANCELED will be the default code. The fixed error code is also more consistent with gRPC code.