### PR TITLE
fix: eris.Is() always returns true for two non-eris errors

### DIFF
--- a/eris_test.go
+++ b/eris_test.go
@@ -420,6 +420,11 @@ func TestErrorIs(t *testing.T) {
 			compare: externalErr,
 			output:  true,
 		},
+		"comparing against different external error": {
+			cause:   errors.New("external error 1"),
+			compare: errors.New("external error 2"),
+			output:  false,
+		},
 		"comparing against custom error type": {
 			cause:   customErr,
 			input:   []string{"even more context"},


### PR DESCRIPTION
## What's changed and what's your intention?
### Issue description

In current implementation, this will returns true
```golang
eris.Is(errors.New("abc"), errors.New("xyz"))
```

That's caused by a bug in `func eq()`:
```golang
return reflect.DeepEqual(kvA, kvB) && codeA == codeB && msgA == msgB
// but for two non-eris errors, kv, code and msg are all empty.
```

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
