### PR TITLE
TestRootWrapping

### DIFF
--- a/eris_test.go
+++ b/eris_test.go
@@ -876,16 +876,6 @@ func TestWrapType(t *testing.T) {
 	}
 }
 
-// eris.Wrapf(err, "failed to get user by email %s", email)
-// results in below, but the SQLSTATE 42703 should be root
-//
-//	{
-//	    "external": "ERROR: column \"password\" does not exist (SQLSTATE 42703)",
-//	    "root": {
-//	        "code": "internal",
-//	        "message": "failed to get user by email dummy@email.com"
-//	    }
-//	}
 func TestRootWrapping(t *testing.T) {
 	col := "password"
 	rootErr := fmt.Errorf("ERROR: column \"%s\" does not exist (SQLSTATE 42703)", col)

--- a/eris_test.go
+++ b/eris_test.go
@@ -878,9 +878,10 @@ func TestWrapType(t *testing.T) {
 
 func TestRootWrapping(t *testing.T) {
 	col := "password"
-	rootErr := fmt.Errorf("ERROR: column \"%s\" does not exist (SQLSTATE 42703)", col)
+	rootErr := eris.Errorf("ERROR: column \"%s\" does not exist (SQLSTATE 42703)", col)
 	email := "dummy@email.com"
-	wrappedErr := eris.Wrapf(rootErr, "failed to get user by email %s", email)
+	wrapMsg := fmt.Sprintf("failed to get user by email %s", email)
+	wrappedErr := eris.Wrapf(rootErr, wrapMsg)
 
 	// validate nested error string
 	expect := "code(internal) failed to get user by email dummy@email.com: ERROR: column \"password\" does not exist (SQLSTATE 42703)"
@@ -902,12 +903,11 @@ func TestRootWrapping(t *testing.T) {
 		t.Errorf("Expected %s, got %s", expectRoot, unwrapGot)
 	}
 
-	// test unpack external
+	// error chain
 	unpacked := eris.Unpack(wrappedErr)
-	gotUnpackExtMsg := unpacked.ErrExternal.Error()
-	expectedUnpackExtMsg := wrappedErr.Error()
-	if gotUnpackExtMsg != expectedUnpackExtMsg {
-		t.Errorf("Expected %s, got %s", expectedUnpackExtMsg, gotUnpackExtMsg)
+	firstErr := unpacked.ErrChain[0].Msg
+	if firstErr != wrapMsg {
+		t.Errorf("Expected %s, got %s", wrapMsg, firstErr)
 	}
 
 	// test unpack root


### PR DESCRIPTION
## What's changed and what's your intention?

`eris.Wrapf(err, "failed to get user by email %s", email)`
results in below, but the `SQLSTATE 42703` should be root

```
{
    "external": "ERROR: column \"password\" does not exist (SQLSTATE 42703)",
    "root": {
        "code": "internal",
        "message": "failed to get user by email dummy@email.com"
    }
}
```

## Checklist

- [ ] I have written the necessary docs and comments
- [ ] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
