### PR TITLE
feat: add `PassThrough` method to pass on the code and properties

### DIFF
--- a/eris.go
+++ b/eris.go
@@ -128,6 +128,35 @@ func Wrapf(err error, format string, args ...any) error {
 	return wrap(err, fmt.Sprintf(format, args...), DEFAULT_ERROR_CODE_WRAP)
 }
 
+// PassThrough adds additional context to all error types while maintaining the type of the original error.
+//
+// This method behaves like Wrap but will copy the code and properties from underlying error.
+func PassThrough(err error, msg string) error {
+	return PassThroughf(err, fmt.Sprint(msg))
+}
+
+// PassThroughf adds additional context to all error types while maintaining the type of the original error.
+//
+// This is a convenience method for wrapping errors with formatted messages and is otherwise the same as PassThrough.
+func PassThroughf(err error, format string, args ...any) error {
+	if err == nil {
+		return nil
+	}
+	newErr := wrap(err, fmt.Sprintf(format, args...), DEFAULT_ERROR_CODE_WRAP)
+
+	code := GetCode(err)
+	if code != CodeUnknown {
+		newErr = WithCode(newErr, code)
+	}
+	kvs := GetKVs(err)
+	if kvs != nil {
+		for k, v := range kvs {
+			newErr = WithProperty(newErr, k, v)
+		}
+	}
+	return newErr
+}
+
 func wrap(err error, msg string, code Code) error {
 	if err == nil {
 		return nil

--- a/eris.go
+++ b/eris.go
@@ -149,10 +149,8 @@ func PassThroughf(err error, format string, args ...any) error {
 		newErr = WithCode(newErr, code)
 	}
 	kvs := GetKVs(err)
-	if kvs != nil {
-		for k, v := range kvs {
-			newErr = WithProperty(newErr, k, v)
-		}
+	for k, v := range kvs {
+		newErr = WithProperty(newErr, k, v)
 	}
 	return newErr
 }


### PR DESCRIPTION
## What's changed and what's your intention?
`eris.PassThrough` is almost like `eris.Wrap`, but it will copy the original error code and properties. (looks like only add a new message)
Therefore, we can use `eris.PassThrough` when we want to add an additional message but don't want to override the underlying status. (e.g.  pass through the error in `modeltx.Query`)

I guess this method will have lots of use cases. So the function name `eris.PassThrough` seems a bit long. And idea? `eris.Pass`?

## Checklist

- [x] I have written the necessary docs and comments
- [x] I have added necessary unit tests and integration tests

## Refer to a related PR or issue link (optional)
